### PR TITLE
Added Windows compatible translation of "hoist-cli" script

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@
 </p>
 
 ### Reporting Bugs/Feature Requests
-
+ 
 [![Open Bugs](https://img.shields.io/github/issues/aws-amplify/amplify-category-api/bug?color=d73a4a&label=bugs)](https://github.com/aws-amplify/amplify-category-api/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
 [![Feature Requests](https://img.shields.io/github/issues/aws-amplify/amplify-category-api/feature-request?color=ff9001&label=feature%20requests)](https://github.com/aws-amplify/amplify-category-api/issues?q=is%3Aissue+label%3Afeature-request+is%3Aopen)
 [![Enhancements](https://img.shields.io/github/issues/aws-amplify/amplify-category-api/enhancement?color=4287f5&label=enhancement)](https://github.com/aws-amplify/amplify-category-api/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "setup-dev": "(yarn && lerna run build) && yarn add-cli-no-save && (yarn hoist-cli && yarn rm-dev-link && yarn link-dev)",
     "link-win": "node ./scripts/link-bin.js node_modules/amplify-cli-internal/bin/amplify amplify-dev",
     "link-aa-win": "node ./scripts/link-bin.js packages/amplify-app/bin/amplify-app amplify-app-dev",
-    "setup-dev-win": "(yarn && lerna run build) && yarn add-cli-no-save && (yarn hoist-cli && yarn rm-dev-link && yarn link-win)",
+    "setup-dev-win": "(yarn && lerna run build) && yarn add-cli-no-save && (yarn hoist-cli-win && yarn rm-dev-link && yarn link-win)",
     "split-e2e-tests": "yarn ts-node ./scripts/split-e2e-tests.ts && git add .circleci/config.yml",
     "verify-commit": "yarn ts-node ./scripts/verify-commit.ts",
     "publish:beta": "lerna publish --exact --dist-tag=beta --preid=beta --conventional-commits --conventional-prerelease --message 'chore(release): Publish [ci skip]' --no-verify-access --yes",
@@ -45,6 +45,7 @@
     "coverage": "codecov || exit 0",
     "add-cli-no-save": "yarn add @aws-amplify/cli-internal -W  && git checkout -- package.json",
     "hoist-cli": "rm -rf node_modules/amplify-cli-internal && mkdir node_modules/amplify-cli-internal && cp -r node_modules/@aws-amplify/cli-internal/* node_modules/amplify-cli-internal",
+    "hoist-cli-win": "rimraf node_modules/amplify-cli-internal && mkdir node_modules\\amplify-cli-internal && xcopy /e /q node_modules\\@aws-amplify\\cli-internal node_modules\\amplify-cli-internal\\",
     "publish:main": "lerna publish --canary --force-publish --preid=alpha --exact --include-merged-tags --conventional-prerelease --no-verify-access --yes"
   },
   "bugs": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Created a script called `hoist-cli-win` to be used by `setup-dev-win`. 

The new script `hoist-cli-win` is a translation of the `hoist-cli`, where:

1. `rm -rf` is replaced by `rimraf` 
2. `cp -r` is replaced by `xcopy /e /q`
3. `/` is replaced by `\\` in the path


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
[540](https://github.com/aws-amplify/amplify-category-api/issues/540) 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Validated by changing updating the scripts and running the setup again on Windows.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
